### PR TITLE
[Fix] 상단 스크롤 해결

### DIFF
--- a/src/hooks/useInfiniteCarousel.ts
+++ b/src/hooks/useInfiniteCarousel.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import {
   buildInfiniteItems,
   getActualIndexFromInfinite,
@@ -11,6 +11,7 @@ interface UseInfiniteCarouselParams<T> {
   images: readonly string[];
   maxRealItems?: number;
   idleMs?: number;
+  initialActualIndex?: number;
 }
 
 interface UseInfiniteCarouselResult<T> {
@@ -28,70 +29,70 @@ interface UseInfiniteCarouselResult<T> {
   centerToIndex: (index: number, behavior?: ScrollBehavior) => void;
 }
 
+const useIsomorphicLayoutEffect = typeof window !== "undefined" ? useLayoutEffect : useEffect;
+
 export function useInfiniteCarousel<T>({
   items,
   images,
   maxRealItems = 6,
   idleMs = 140,
+  initialActualIndex = 0,
 }: UseInfiniteCarouselParams<T>): UseInfiniteCarouselResult<T> {
+  const safeItems = items ?? [];
+  const safeImages = images ?? [];
+
   const carouselRef = useRef<HTMLDivElement>(null);
   const itemRefs = useRef<(HTMLDivElement | null)[]>([]);
 
   const isJumpingRef = useRef(false);
   const currentIndexRef = useRef(0);
+
   const scrollRafRef = useRef<number | null>(null);
   const scrollIdleTimerRef = useRef<number | null>(null);
 
-  const realItems = useMemo(
-    () => items.slice(0, maxRealItems),
-    [items, maxRealItems],
-  );
+  const realItems = useMemo(() => safeItems.slice(0, maxRealItems), [safeItems, maxRealItems]);
   const realLen = realItems.length;
 
-  const infiniteItems = useMemo(
-    () => buildInfiniteItems(realItems),
-    [realItems],
+  const infiniteItems = useMemo(() => buildInfiniteItems(realItems), [realItems]);
+
+  const startIndex = useMemo(
+    () => getStartInfiniteIndex(realLen, initialActualIndex),
+    [realLen, initialActualIndex]
   );
 
-  const [currentIndex, setCurrentIndex] = useState(0);
-  const [activeBackgroundImage, setActiveBackgroundImage] = useState<string>(
-    () => images[0] ?? "",
-  );
+  const [currentIndex, setCurrentIndex] = useState(() => startIndex);
+
+  const [activeBackgroundImage, setActiveBackgroundImage] = useState<string>("");
 
   const getActualIndex = useCallback(
-    (infiniteIndex: number) =>
-      getActualIndexFromInfinite(infiniteIndex, realLen),
-    [realLen],
+    (infiniteIndex: number) => getActualIndexFromInfinite(infiniteIndex, realLen),
+    [realLen]
   );
 
   const setItemRef = useCallback(
     (index: number) => (el: HTMLDivElement | null) => {
       itemRefs.current[index] = el;
     },
-    [],
+    []
   );
 
-  const centerToIndex = useCallback(
-    (index: number, behavior: ScrollBehavior = "auto") => {
-      const carousel = carouselRef.current;
-      const card = itemRefs.current[index];
-      if (!carousel || !card) return;
+  const centerToIndex = useCallback((index: number, behavior: ScrollBehavior = "auto") => {
+    const carousel = carouselRef.current;
+    const card = itemRefs.current[index];
+    if (!carousel || !card) return;
 
-      const prev = carousel.style.scrollBehavior;
-      if (behavior === "auto") carousel.style.scrollBehavior = "auto";
+    const prev = carousel.style.scrollBehavior;
+    if (behavior === "auto") carousel.style.scrollBehavior = "auto";
 
-      const left =
-        card.offsetLeft - (carousel.clientWidth - card.clientWidth) / 2;
-      carousel.scrollTo({ left, behavior });
+    const left = card.offsetLeft - (carousel.clientWidth - card.clientWidth) / 2;
+    carousel.scrollTo({ left, behavior });
 
-      if (behavior === "auto") {
-        requestAnimationFrame(() => {
-          carousel.style.scrollBehavior = prev;
-        });
-      }
-    },
-    [],
-  );
+    if (behavior === "auto") {
+      requestAnimationFrame(() => {
+        carousel.style.scrollBehavior = prev;
+      });
+    }
+  }, []);
 
   useEffect(() => {
     itemRefs.current = itemRefs.current.slice(0, infiniteItems.length);
@@ -100,6 +101,67 @@ export function useInfiniteCarousel<T>({
   useEffect(() => {
     currentIndexRef.current = currentIndex;
   }, [currentIndex]);
+
+  useIsomorphicLayoutEffect(() => {
+    if (realLen === 0) return;
+
+    let cancelled = false;
+
+    const tryCenter = () => {
+      if (cancelled) return;
+
+      const carousel = carouselRef.current;
+      const card = itemRefs.current[startIndex];
+
+      if (!carousel || !card) {
+        requestAnimationFrame(tryCenter);
+        return;
+      }
+
+      centerToIndex(startIndex, "auto");
+    };
+
+    tryCenter();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [centerToIndex, realLen, startIndex]);
+
+  useEffect(() => {
+    if (realLen === 0) return;
+
+    const id = requestAnimationFrame(() => {
+      const actual = getActualIndexFromInfinite(currentIndexRef.current, realLen);
+      setActiveBackgroundImage(safeImages[actual] ?? safeImages[0] ?? "");
+    });
+
+    return () => cancelAnimationFrame(id);
+  }, [realLen, safeImages]);
+
+  useEffect(() => {
+    if (realLen === 0) return;
+
+    const id = requestAnimationFrame(() => {
+      const actual = getActualIndexFromInfinite(currentIndex, realLen);
+      setActiveBackgroundImage(safeImages[actual] ?? safeImages[0] ?? "");
+    });
+
+    return () => cancelAnimationFrame(id);
+  }, [currentIndex, realLen, safeImages]);
+
+  useEffect(() => {
+    const carousel = carouselRef.current;
+    if (!carousel) return;
+    if (typeof ResizeObserver === "undefined") return;
+
+    const ro = new ResizeObserver(() => {
+      centerToIndex(currentIndexRef.current, "auto");
+    });
+
+    ro.observe(carousel);
+    return () => ro.disconnect();
+  }, [centerToIndex]);
 
   const findClosestIndex = useCallback(() => {
     const carousel = carouselRef.current;
@@ -122,6 +184,7 @@ export function useInfiniteCarousel<T>({
         bestIdx = i;
       }
     }
+
     return bestIdx;
   }, []);
 
@@ -132,46 +195,15 @@ export function useInfiniteCarousel<T>({
 
       isJumpingRef.current = true;
 
+      centerToIndex(target, "auto");
+      setCurrentIndex(target);
+
       requestAnimationFrame(() => {
-        centerToIndex(target, "auto");
-        setCurrentIndex(target);
-
-        const actual = getActualIndexFromInfinite(target, realLen);
-        setActiveBackgroundImage(images[actual] ?? images[0] ?? "");
-
-        requestAnimationFrame(() => {
-          isJumpingRef.current = false;
-        });
+        isJumpingRef.current = false;
       });
     },
-    [centerToIndex, images, realLen],
+    [centerToIndex, realLen]
   );
-
-  useEffect(() => {
-    if (realLen === 0) return;
-
-    requestAnimationFrame(() => {
-      const start = getStartInfiniteIndex(realLen);
-      centerToIndex(start, "auto");
-      setCurrentIndex(start);
-
-      const actual = getActualIndexFromInfinite(start, realLen);
-      setActiveBackgroundImage(images[actual] ?? images[0] ?? "");
-    });
-  }, [centerToIndex, images, realLen]);
-
-  useEffect(() => {
-    const carousel = carouselRef.current;
-    if (!carousel) return;
-    if (typeof ResizeObserver === "undefined") return;
-
-    const ro = new ResizeObserver(() => {
-      centerToIndex(currentIndexRef.current, "auto");
-    });
-
-    ro.observe(carousel);
-    return () => ro.disconnect();
-  }, [centerToIndex]);
 
   useEffect(() => {
     const carousel = carouselRef.current;
@@ -184,15 +216,11 @@ export function useInfiniteCarousel<T>({
       scrollRafRef.current = requestAnimationFrame(() => {
         const idx = findClosestIndex();
         if (idx >= 0 && idx !== currentIndexRef.current) {
-          setCurrentIndex(idx);
-
-          const actual = getActualIndexFromInfinite(idx, realLen);
-          setActiveBackgroundImage(images[actual] ?? images[0] ?? "");
+          setCurrentIndex(idx); // ✅ index만 바꿈
         }
       });
 
-      if (scrollIdleTimerRef.current)
-        window.clearTimeout(scrollIdleTimerRef.current);
+      if (scrollIdleTimerRef.current) window.clearTimeout(scrollIdleTimerRef.current);
       scrollIdleTimerRef.current = window.setTimeout(() => {
         const idx = findClosestIndex();
         if (idx >= 0) jumpIfClone(idx);
@@ -203,10 +231,9 @@ export function useInfiniteCarousel<T>({
     return () => {
       carousel.removeEventListener("scroll", onScroll);
       if (scrollRafRef.current) cancelAnimationFrame(scrollRafRef.current);
-      if (scrollIdleTimerRef.current)
-        window.clearTimeout(scrollIdleTimerRef.current);
+      if (scrollIdleTimerRef.current) window.clearTimeout(scrollIdleTimerRef.current);
     };
-  }, [findClosestIndex, images, idleMs, jumpIfClone, realLen]);
+  }, [findClosestIndex, idleMs, jumpIfClone]);
 
   return {
     carouselRef,

--- a/src/utils/infiniteCarousel.ts
+++ b/src/utils/infiniteCarousel.ts
@@ -1,43 +1,33 @@
 export function buildInfiniteItems<T>(realItems: readonly T[]): T[] {
-  const len = realItems.length;
+  const len = realItems?.length ?? 0;
   if (len === 0) return [];
   if (len === 1) return [realItems[0]];
 
-  return [realItems[len - 1], ...realItems, realItems[0], realItems[1 % len]];
+  return [...realItems, ...realItems, ...realItems];
 }
 
-export function getActualIndexFromInfinite(
-  infiniteIndex: number,
-  realLen: number,
-): number {
+export function getActualIndexFromInfinite(infiniteIndex: number, realLen: number): number {
   if (realLen <= 0) return 0;
   if (realLen === 1) return 0;
 
-  if (infiniteIndex === 0) return realLen - 1;
-
-  if (infiniteIndex <= realLen) return infiniteIndex - 1;
-
-  return infiniteIndex - realLen - 1;
+  const m = infiniteIndex % realLen;
+  return m < 0 ? m + realLen : m;
 }
 
-export function getStartInfiniteIndex(realLen: number): number {
+export function getStartInfiniteIndex(realLen: number, initialActualIndex = 0): number {
   if (realLen <= 0) return 0;
-  return realLen >= 2 ? 1 : 0;
+  if (realLen === 1) return 0;
+
+  const actual = ((initialActualIndex % realLen) + realLen) % realLen;
+  return realLen + actual;
 }
 
-export function getJumpTarget(
-  infiniteIndex: number,
-  realLen: number,
-): number | null {
-  if (realLen < 2) return null;
+export function getJumpTarget(infiniteIndex: number, realLen: number): number | null {
+  if (realLen <= 1) return null;
 
-  const lastReal = realLen;
-  const firstClone = realLen + 1;
-  const secondClone = realLen + 2;
+  if (infiniteIndex < realLen) return infiniteIndex + realLen;
 
-  if (infiniteIndex === 0) return lastReal;
-  if (infiniteIndex === firstClone) return 1;
-  if (infiniteIndex === secondClone) return 2;
+  if (infiniteIndex >= realLen * 2) return infiniteIndex - realLen;
 
   return null;
 }


### PR DESCRIPTION
<!-- 'Closes #' 다음에 완료한 이슈 넘버를 작성해 주세요. ex) Closes #4 -->

## 🔗 관련 이슈

Closes #47


## 💡 작업 내용

- 데스크탑 환경에서 트렌딩 캐러셀 초기 위치/활성 카드가 어긋나던 문제 및 스크롤 중 예외 발생을 해결했습니다.
- `useInfiniteCarousel` 훅을 개선해 초기 인덱스를 가운데 구간에서 시작하도록 변경하고, 초기 센터링을 `useLayoutEffect`(isomorphic) 기반으로 처리했습니다.
- 배경 이미지(activeBackgroundImage) 업데이트를 `requestAnimationFrame` 기반으로 지연 반영해 초기 렌더/스크롤 동작 시 렌더 충돌을 줄이고 안정성을 높였습니다.
- `infiniteCarousel` 유틸을 “3배 복제 방식([real, real, real])”으로 변경해 데스크탑 넓은 뷰포트에서도 무한 스크롤 점프/클론 처리 로직이 일관되게 동작하도록 수정했습니다.
- `items/images`가 일시적으로 undefined가 되는 상황(HMR/리프레시 등)에 대비해 안전한 기본값(safeItems/safeImages) 방어 로직을 추가했습니다.

<br/>

## 💬 기억하면 좋을 내용(선택)

- 훅 호출 순서 경고/에러가 발생했던 경우, HMR 상태가 꼬여 연쇄 에러가 날 수 있어 적용 후 하드 리로드(Ctrl+Shift+R)로 상태를 정리하면 안정적으로 확인할 수 있습니다.
- 기존 “끝에 클론 몇 개만 붙이는 방식” 대비 3배 복제 방식은 뷰포트가 넓은 데스크탑에서도 초기 센터링/무한 점프가 더 안정적입니다.
